### PR TITLE
Fixed hardcoded directory path and ToEventSum function

### DIFF
--- a/torchneuromorphic/nmnist/nmnist_dataloaders.py
+++ b/torchneuromorphic/nmnist/nmnist_dataloaders.py
@@ -35,8 +35,6 @@ mapping = { 0 :'0',
 class NMNISTDataset(NeuromorphicDataset):
     resources_url = [['https://www.dropbox.com/sh/tg2ljlbmtzygrag/AABlMOuR15ugeOxMCX0Pvoxga/Train.zip?dl=1',None, 'Train.zip'],
                      ['https://www.dropbox.com/sh/tg2ljlbmtzygrag/AADSKgJ2CjaBWh75HnTNZyhca/Test.zip?dl=1', None, 'Test.zip']]
-    directory = '/home/kennetms/Documents/accenture-gesture-learning-v2/VAE/data/nmnist/'
-    resources_local = [directory+'Train', directory+'Test']
 
     def __init__(
             self, 
@@ -55,12 +53,12 @@ class NMNISTDataset(NeuromorphicDataset):
         self.train = train 
         self.dt = dt
         self.chunk_size = chunk_size
-
+        self.directory = root.split('n_mnist.hdf5')[0]
+        self.resources_local = [self.directory + 'Train', self.directory + 'Test']
         super(NMNISTDataset, self).__init__(
                 root,
                 transform=transform,
                 target_transform=target_transform )
-        
         with h5py.File(root, 'r', swmr=True, libver="latest") as f:
             try:
                 if train:

--- a/torchneuromorphic/transforms.py
+++ b/torchneuromorphic/transforms.py
@@ -224,7 +224,7 @@ class ToEventSum(object):
             idx_end += find_first(times[idx_end:], t)
             if idx_end > idx_start:
                 ee = addrs[idx_start:idx_end]
-                i_pol_x_y = tuple([i] + [ee[:, j] for j in range(self.ndim)])
+                i_pol_x_y = tuple([i] + [ee[:, j] for j in range(ee.shape[-1])])
                 np.add.at(chunks, i_pol_x_y, 1)
             idx_start = idx_end
         return chunks.sum(axis=0, keepdims=True)


### PR DESCRIPTION
- Fixed a hardcoded directory path that caused new installations to fail.
- Fixed missing `self.ndim` in `ToEventSum`